### PR TITLE
Remove "Measurement" state class from battery sensor.

### DIFF
--- a/custom_components/sonic/sensor.py
+++ b/custom_components/sonic/sensor.py
@@ -146,7 +146,7 @@ class SonicBatterySensor(SonicEntity, SensorEntity):
 
     _attr_icon = BATTERY_ICON
     _attr_native_unit_of_measurement = "battery"
-    _attr_state_class: SensorStateClass = SensorStateClass.MEASUREMENT
+    _attr_state_class: SensorStateClass = SensorStateClass.None
 
     def __init__(self, device):
         """Initialize the battery sensor."""


### PR DESCRIPTION
Using state_class of SensorStateClass.MEASUREMENT leads to warning from HA about expecting numeric value.  Sonic battery level is only ever returned as string "high, medium, low"

See: https://github.com/markvader/sonic/issues/23